### PR TITLE
Refactor ConversationForm and StartConversationForm to remove unused …

### DIFF
--- a/app/components/chat/ConversationForm.tsx
+++ b/app/components/chat/ConversationForm.tsx
@@ -1,5 +1,5 @@
 import { Flex, Group, Textarea } from '@mantine/core'
-import { useState, useEffect, useRef } from 'react'
+import { useEffect, useRef } from 'react'
 import * as v from 'valibot'
 import classes from './ConversationForm.module.css'
 import inputValidationSchema from './inputValidationSchema'
@@ -7,8 +7,6 @@ import SendMessageButton from './SendMessageButton'
 import useSharedChat from './useSharedChat'
 
 const ConversationForm = () => {
-	const [isCompositionInput, setIsCompositionInput] = useState(false)
-
 	const {
 		input,
 		status,
@@ -51,14 +49,12 @@ const ConversationForm = () => {
 				classNames={{ wrapper: 'flex-1', input: classes.textarea }}
 				value={input}
 				onChange={handleInputChange}
-				onCompositionStart={() => setIsCompositionInput(true)}
-				onCompositionEnd={() => setIsCompositionInput(false)}
 				onKeyDown={(event) => {
 					const canSendMessage =
 						(status === 'ready' || status === 'error') &&
 						event.key === 'Enter' &&
 						!event.shiftKey &&
-						!isCompositionInput &&
+						!event.nativeEvent.isComposing &&
 						isInputValid
 
 					if (canSendMessage) {

--- a/app/components/chat/StartConversationForm.tsx
+++ b/app/components/chat/StartConversationForm.tsx
@@ -1,6 +1,5 @@
-import { Flex, Group, Stack, Textarea } from '@mantine/core'
+import { Flex, Group, Textarea } from '@mantine/core'
 import { useInputState } from '@mantine/hooks'
-import { useState } from 'react'
 import { useFetcher } from 'react-router'
 import * as v from 'valibot'
 import classes from './ConversationForm.module.css'
@@ -8,8 +7,6 @@ import inputValidationSchema from './inputValidationSchema'
 import SendMessageButton from './SendMessageButton'
 
 const StartConversationForm = () => {
-	const [isCompositionInput, setIsCompositionInput] = useState(false)
-
 	const fetcher = useFetcher()
 
 	const [input, handleInputChange] = useInputState('')
@@ -29,14 +26,12 @@ const StartConversationForm = () => {
 				classNames={{ wrapper: 'flex-1', input: classes.textarea }}
 				value={input}
 				onChange={handleInputChange}
-				onCompositionStart={() => setIsCompositionInput(true)}
-				onCompositionEnd={() => setIsCompositionInput(false)}
 				onKeyDown={async (event) => {
 					const canSendMessage =
 						fetcher.state === 'idle' &&
 						event.key === 'Enter' &&
 						!event.shiftKey &&
-						!isCompositionInput &&
+						!event.nativeEvent.isComposing &&
 						isInputValid
 
 					if (canSendMessage) {


### PR DESCRIPTION
This pull request refactors the handling of composition input in the `ConversationForm` and `StartConversationForm` components by removing the `isCompositionInput` state and replacing it with the `isComposing` property of the native event. Additionally, unused imports were cleaned up in both files.

### Refactoring of composition input handling:

* [`app/components/chat/ConversationForm.tsx`](diffhunk://#diff-70d5168b66749c119eecb1500651a473403a8e284054002997707ec556d2dcb3L2-L11): Removed the `isCompositionInput` state and its associated event handlers (`onCompositionStart` and `onCompositionEnd`). Updated the `onKeyDown` handler to use `event.nativeEvent.isComposing` instead of relying on the removed state. [[1]](diffhunk://#diff-70d5168b66749c119eecb1500651a473403a8e284054002997707ec556d2dcb3L2-L11) [[2]](diffhunk://#diff-70d5168b66749c119eecb1500651a473403a8e284054002997707ec556d2dcb3L54-R57)
* [`app/components/chat/StartConversationForm.tsx`](diffhunk://#diff-f17989f40ccac85dd26f6a8c3c609ab219277054c1535779620b746418933956L1-L12): Similarly removed the `isCompositionInput` state and its associated event handlers. Updated the `onKeyDown` handler to use `event.nativeEvent.isComposing`. [[1]](diffhunk://#diff-f17989f40ccac85dd26f6a8c3c609ab219277054c1535779620b746418933956L1-L12) [[2]](diffhunk://#diff-f17989f40ccac85dd26f6a8c3c609ab219277054c1535779620b746418933956L32-R34)

### Cleanup of unused imports:

* [`app/components/chat/ConversationForm.tsx`](diffhunk://#diff-70d5168b66749c119eecb1500651a473403a8e284054002997707ec556d2dcb3L2-L11): Removed the unused `useState` import.
* [`app/components/chat/StartConversationForm.tsx`](diffhunk://#diff-f17989f40ccac85dd26f6a8c3c609ab219277054c1535779620b746418933956L1-L12): Removed the unused `useState` and `Stack` imports.