### PR TITLE
refactor: migrate public hoist pattern for prettier-plugin-tailwindcs…

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+public-hoist-pattern[]=*prettier-plugin-tailwindcss*

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,0 @@
-publicHoistPattern:
-  - 'prettier-plugin-tailwindcss'


### PR DESCRIPTION
This pull request updates the configuration files to modify how `prettier-plugin-tailwindcss` is hoisted in the workspace. The changes involve transitioning from a `pnpm-workspace.yaml` configuration to `.npmrc`.

Configuration updates:

* [`.npmrc`](diffhunk://#diff-e813096d69c49812e40e00be9ac8fa14d77f0ec1f97ab4c45cb096b3bedd35deR1): Added a new `public-hoist-pattern` entry for `*prettier-plugin-tailwindcss*`.
* [`pnpm-workspace.yaml`](diffhunk://#diff-18ae0a0fab29a7db7aded913fd05f30a2c8f6c104fadae86c9d217091709794cL1-L2): Removed the `publicHoistPattern` entry for `prettier-plugin-tailwindcss`.